### PR TITLE
sst_graphics_infrastructure/X11-server: Remove i686

### DIFF
--- a/configs/sst_graphics_infrastructure-X11-server.yaml
+++ b/configs/sst_graphics_infrastructure-X11-server.yaml
@@ -44,16 +44,6 @@ data:
     - xorg-x11-drv-v4l
     - xorg-x11-drv-vmware
     - xorg-x11-drv-wacom
-    i686:
-    # xorg-x11-drivers
-    - xorg-x11-drv-dummy
-    - xorg-x11-drv-evdev
-    - xorg-x11-drv-fbdev
-    - xorg-x11-drv-libinput
-    - xorg-x11-drv-modesetting
-    - xorg-x11-drv-v4l
-    - xorg-x11-drv-vmware
-    - xorg-x11-drv-wacom  
 
   labels:
     - eln


### PR DESCRIPTION
There's no 32-bit server, so there's no need for 32-bit drivers.

---

I have no idea whether this will actually have the desired effect, but hopefully the intent is clear.